### PR TITLE
Support gnome 45

### DIFF
--- a/eval-gjs@ramottamado.dev/extension.js
+++ b/eval-gjs@ramottamado.dev/extension.js
@@ -1,3 +1,8 @@
+import Gio from 'gi://Gio';
+import Meta from 'gi://Meta';
+import GLib from 'gi://GLib';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
 /* extension.js
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,14 +21,6 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-/* exported init */
-
-'use strict';
-
-const { Gio, GLib, Meta } = imports.gi;
-
-const Main = imports.ui.main;
-
 const EvalGjsIface =
     '<node>' +
     '   <interface name="dev.ramottamado.EvalGjs">' +
@@ -35,7 +32,7 @@ const EvalGjsIface =
     '   </interface>' +
     '</node>';
 
-class EvalGjs {
+export default class EvalGjs {
     constructor() {
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(EvalGjsIface, this);
     }
@@ -84,8 +81,4 @@ class EvalGjs {
     disable() {
         if (this._dbusImpl) this._dbusImpl.unexport();
     }
-}
-
-function init() {
-    return new EvalGjs();
 }

--- a/eval-gjs@ramottamado.dev/metadata.json
+++ b/eval-gjs@ramottamado.dev/metadata.json
@@ -3,10 +3,7 @@
   "description": "Evaluate GJS script through DBus",
   "uuid": "eval-gjs@ramottamado.dev",
   "shell-version": [
-    "41",
-    "42",
-    "43",
-    "44"
+    "45"
   ],
   "url": "https://github.com/ramottamado/eval-gjs"
 }


### PR DESCRIPTION
Migrated the extension to GNOME 45's ESM API, which also means older shell versions must be dropped.

How to install directly:
```bash
git clone https://github.com/salemkode/eval-gjs
cd eval-gjs@ramottamado.dev
cp -r eval-gjs@ramottamado.dev ~/.local/share/gnome-shell/extensions/
```
